### PR TITLE
Disable the Jenkins CLI for all instances

### DIFF
--- a/Dockerfile.master
+++ b/Dockerfile.master
@@ -16,5 +16,5 @@ RUN date > /usr/share/jenkins/ref/userContent/builtOn.txt
 ADD build/git-refs.txt /usr/share/jenkins/ref/userContent
 RUN for f in /usr/share/jenkins/ref/userContent/*.txt; do ln -s $f $f.override ; done
 
-ENV JAVA_OPTS="-Djenkins.install.runSetupWizard=false -Dhudson.DNSMultiCast.disabled=true"
+ENV JAVA_OPTS="-Djenkins.install.runSetupWizard=false -Dhudson.DNSMultiCast.disabled=true -Djenkins.CLI.disabled=true"
 USER jenkins


### PR DESCRIPTION
No need to keep this on.

This will satisfy some of #19, but there are still some agent-communication
things which need to be changed there.