### PR TITLE
Set the default Docker Label for Pipeline

### DIFF
--- a/init.groovy.d/pipeline-global-configuration.groovy
+++ b/init.groovy.d/pipeline-global-configuration.groovy
@@ -1,0 +1,14 @@
+#!/usr/bin/env groovy
+
+/*
+ * This file is responsible for setting Global Pipeline configurations to the
+ * sensible defaults which are necessary
+ */
+
+import jenkins.model.GlobalConfiguration
+import org.jenkinsci.plugins.pipeline.modeldefinition.config.GlobalConfig
+
+
+/* Set the default Docker label for Declarative Pipeline to .. wait for it .. docker */
+GlobalConfig c = GlobalConfiguration.all().find { it instanceof GlobalConfig }
+c?.dockerLabel = 'docker'


### PR DESCRIPTION
Now that there is more than one kind of agent available, we need to explicitly
state where a Docker workload should run.

Fixes #33