### PR TITLE
Replicate the in-container build of gems/native extensions used in canary

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,12 +1,11 @@
 FROM ruby:2.3-alpine
 
+ARG BUILD_PKGS="ruby-dev openssl-dev gcc make libc-dev binutils"
 ARG APP_DIR=/webapp
 
 RUN mkdir -p ${APP_DIR}/vendor
 
 WORKDIR ${APP_DIR}
-
-ADD vendor/ ${APP_DIR}/vendor/
 
 ENV GEM_HOME=${APP_DIR}/vendor/gems
 ENV BUNDLE_PATH=${APP_DIR}/vendor/gems
@@ -19,4 +18,10 @@ ADD monkeys.txt ${APP_DIR}/
 ADD config.ru ${APP_DIR}/
 ADD views ${APP_DIR}/views/
 ADD assets ${APP_DIR}/assets/
+
+RUN apk add -U ${BUILD_PKGS} && \
+        bundle install && \
+        apk del ${BUILD_PKGS} && \
+        rm -rf /var/cache/apk/*
+
 CMD bundle exec puma

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -1,13 +1,19 @@
 
-all: depends
+all: check container
 
-check: depends container
+check: spec check-container
 
 depends: Gemfile
 	./scripts/ruby bundle install
 
+spec: depends
+	./scripts/ruby bundle exec rspec -c
+
 run: depends monkeys.txt
 	./scripts/ruby bundle exec puma
+
+check-container: container
+	docker run --rm rtyler/codevalet-webapp:latest bundle exec puma --version
 
 container: depends Dockerfile monkeys.txt
 	docker build -t rtyler/codevalet-webapp .
@@ -18,4 +24,4 @@ clean:
 monkeys.txt: ../monkeys.txt
 	cp ../monkeys.txt .
 
-.PHONY: all depends clean run check container
+.PHONY: all depends clean run check container spec check-container


### PR DESCRIPTION
This hasn't caused issues yet, but I'm sure it would eventually.